### PR TITLE
Enable logging for examples/Lightbulb

### DIFF
--- a/examples/Lightbulb/main/CMakeLists.txt
+++ b/examples/Lightbulb/main/CMakeLists.txt
@@ -1,2 +1,3 @@
 idf_component_register(SRCS ./app_wifi.c ./app_main.c ./DB.c ./App.c
                        INCLUDE_DIRS ".")
+add_definitions(-DHAP_LOG_LEVEL=${CONFIG_HAP_LOG_LEVEL})


### PR DESCRIPTION
Log messages in examples/Lightbulb/main/App.c using HAPLogInfo() are not displayed on the console. Log messages from inside the ADK are working correctly. It appears that HAP_LOG_LEVEL is not defined when compiling the example files and the default value of 0 from HAPLog.h is being used. Update examples/Lightbulb/main/CMakeLists.txt to set the log level based on the value from menuconfig.

This patch worked for me. I don't know enough about CMake to tell if this is the correct way to fix it.